### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ envlist =
 ;  docs,
   flake8
 setenv =
-  VIRTUALENV_PIP = 20.2.4  
+  VIRTUALENV_PIP = 20.2.4
+requires = virtualenv >= 20.0
 
 [base]
 basepython =


### PR DESCRIPTION
These changes to tox.ini are necessary to get a newer version of pip, which can handle manylinux wheels. 

That in turn is necessary so that we don't need to compile the cryptography library from scratch, which now requires rust as a system dependency, which is a bit more of a kerfuffle than we need.

closes #98 