### PR TITLE
allow using of one's own session to download assets

### DIFF
--- a/civic_scraper/base/asset.py
+++ b/civic_scraper/base/asset.py
@@ -61,7 +61,7 @@ class Asset:
     def __repr__(self):
         return f'Asset({self.url})'
 
-    def download(self, target_dir):
+    def download(self, target_dir, session=None):
         """
         Downloads an asset to a target directory.
 
@@ -79,7 +79,10 @@ class Asset:
             self.asset_type,
             file_extension
         )
-        response = requests.get(self.url, allow_redirects=True)
+        if session:
+            response = session.get(self.url, allow_redirects=True)
+        else:
+            response = requests.get(self.url, allow_redirects=True)
         full_path = os.path.join(target_dir, file_name)
         with open(full_path, 'wb') as outfile:
             outfile.write(response.content)


### PR DESCRIPTION
legistar has a bunch of flakiness that we have handled in our LegistarScraper, which are ultimately subclasses of requests Sessions.

if the asset download method can use a custom session, we can take advantage of that, and address issues like. https://github.com/datamade/civic-scraper/pull/8#issuecomment-947764923