### PR TITLE
The span does not appear to be within the h2 tag and the extract removes the h2 tag from the tree

### DIFF
--- a/civic_scraper/platforms/civic_plus/parser.py
+++ b/civic_scraper/platforms/civic_plus/parser.py
@@ -66,9 +66,6 @@ class Parser:
         return metadata
 
     def _committee_name(self, div):
-        # Remove span that contains
-        # arrow ▼ for toggling meeting list
-        div.h2.span.extract()
         return div.h2.text.strip()
 
     def _mtg_title(self, row):


### PR DESCRIPTION
This addresses the issues in #91 and #176 

Tested this change via debugger and the committee names are now being returned like they were before.  I do not know the root cause for why this broke or why this worked before. I spot checked several municipalities websites in the google doc and they were all this way where the span is not in the h2 tag.