### PR TITLE
[Issue 197] Fix readthedocs build (take 3)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,11 @@
 # Read the Docs configuration file for Sphinx projects
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
It turns out that build os _is_ required. This PR adds that to the readthedocs.yml.