### PR TITLE
[Issue 197] Add requirements install to readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,10 @@ build:
   tools:
     python: "3.9"
 
+python:
+  install:
+    - requirements: docs/requirements.txt
+    
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Adds installation of requirements to readthedocs build, via readthedocs.yml.

https://github.com/biglocalnews/civic-scraper/issues/197