### PR TITLE
Downgrade sphinx to version compatible with 3.9

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==8.1.3
+Sphinx==7.4
 sphinx-autobuild==2024.10.3
 myst-parser==4.0.1
 demjson3==3.0.6


### PR DESCRIPTION
Downgrade sphinx to version compatible with 3.9 to enable readthedocs build.

https://github.com/biglocalnews/civic-scraper/issues/197