### PR TITLE
Enable release on tag

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -3,6 +3,7 @@ name: Continuous Deployment
 on:
   push:
     branches: [ master ]
+    tags: ['*']
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Description

The previous PR scoped actions on just push to master, but we also need them to run when there is a tag present to make sure releases happen when a tag is added.