### PR TITLE
Flake improvements

### DIFF
--- a/civic_scraper/base/__init__.py
+++ b/civic_scraper/base/__init__.py
@@ -1,2 +1,4 @@
 from .asset import Asset, AssetCollection
 from .site import Site
+
+__all__ = ["Asset", "AssetCollection", "Site"]

--- a/civic_scraper/base/asset.py
+++ b/civic_scraper/base/asset.py
@@ -12,7 +12,8 @@ class Asset:
     Args:
         url (str): URL to download an asset.
         asset_name (str): Title of an asset. Ex:  City Council Regular Meeting
-        committee_name (str): Name of committee that generated the asset. Ex: City Council
+        committee_name (str): Name of committee that generated the asset.
+            Ex: City Council
         place (str): Name of place associated with the asset.
             Lowercase with spaces and punctuation removed. Ex: menlopark
         place_name (str): Human-readable place name. Ex: Menlo Park
@@ -24,7 +25,8 @@ class Asset:
         meeting_id (str): Unique meeting ID. For example, cominbation of scraper type,
             subdomain and numeric ID or date. Ex: civicplus-nc-nashcounty-05052020-382
         scraped_by (str): civic_scraper.__version__
-        content_type (str): File type of the asset as given by HTTP headers. Ex: 'application/pdf'
+        content_type (str): File type of the asset as given by HTTP headers.
+            Ex: 'application/pdf'
         content_length (str): Asset size in bytes
 
     Public methods:

--- a/civic_scraper/platforms/__init__.py
+++ b/civic_scraper/platforms/__init__.py
@@ -4,3 +4,12 @@ from .digital_tow_path.site import DigitalTowPathSite
 from .granicus.site import GranicusSite
 from .legistar.site import Site as LegistarSite
 from .primegov.site import PrimeGovSite
+
+__all__ = [
+    "CivicClerkSite",
+    "CivicPlusSite",
+    "DigitalTowPathSite",
+    "GranicusSite",
+    "LegistarSite",
+    "PrimeGovSite",
+]

--- a/civic_scraper/platforms/civic_clerk/site.py
+++ b/civic_scraper/platforms/civic_clerk/site.py
@@ -26,7 +26,8 @@ class CivicClerkSite(base.Site):
 
         self.session = Session()
         self.session.headers["User-Agent"] = (
-            "Mozilla/5.0 (X11; CrOS x86_64 12871.102.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36"
+            "Mozilla/5.0 (X11; CrOS x86_64 12871.102.0) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36"
         )
 
         # Raise an error if a request gets a failing status code
@@ -108,7 +109,9 @@ class CivicClerkSite(base.Site):
         callback_id = "aspxroundpanelCurrent$pnlDetails$grdEventsCurrent"
         for page in self._paginate(callback_id):
             events = page.xpath(
-                "//table[@id='aspxroundpanelCurrent_pnlDetails_grdEventsCurrent_DXMainTable']/tr[@class='dxgvDataRow_CustomThemeModerno']"
+                "//table[@id='aspxroundpanelCurrent_pnlDetails"
+                "_grdEventsCurrent_DXMainTable']"
+                "/tr[@class='dxgvDataRow_CustomThemeModerno']"
             )
             yield from events
 
@@ -117,7 +120,9 @@ class CivicClerkSite(base.Site):
         callback_id = "aspxroundpanelRecent2$ASPxPanel4$grdEventsRecent2"
         for page in self._paginate(callback_id):
             events = page.xpath(
-                "//table[@id='aspxroundpanelRecent2_ASPxPanel4_grdEventsRecent2_DXMainTable']/tr[@class='dxgvDataRow_CustomThemeModerno']"
+                "//table[@id='aspxroundpanelRecent2_ASPxPanel4"
+                "_grdEventsRecent2_DXMainTable']"
+                "/tr[@class='dxgvDataRow_CustomThemeModerno']"
             )
             yield from events
 
@@ -150,10 +155,12 @@ class CivicClerkSite(base.Site):
         # it's basically a post request with a 'PBN' argument. But,
         # we also have to pass around the callback state that
         # the endpoint expects
+        xpath_tmpl = (
+            "//script[contains(text(),"
+            " \"var dxo = new ASPxClientGridView('{}');\")]/text()"
+        )
         (event_callback_source,) = tree.xpath(
-            """//script[contains(text(), "var dxo = new ASPxClientGridView('{}');")]/text()""".format(
-                callback_id.replace("$", "_")
-            )
+            xpath_tmpl.format(callback_id.replace("$", "_"))
         )
 
         callback_state = demjson.decode(
@@ -217,7 +224,10 @@ class CivicClerkSite(base.Site):
             meeting_datetime = datetime.strptime(str_datetime, "%m/%d/%Y %I:%M %p")
             meeting_id_num, meeting_id = self.get_meeting_id(event)
 
-            event_url = f"{self.base_url}/Web/DocumentFrame.aspx?id={meeting_id_num}&mod=-1&player_tab=-2"
+            event_url = (
+                f"{self.base_url}/Web/DocumentFrame.aspx"
+                f"?id={meeting_id_num}&mod=-1&player_tab=-2"
+            )
             event_response = self.session.get(event_url, timeout=self.timeout)
 
             agenda_items = self.get_agenda_items(event_response.text)

--- a/civic_scraper/platforms/digital_tow_path/site.py
+++ b/civic_scraper/platforms/digital_tow_path/site.py
@@ -43,7 +43,8 @@ class DigitalTowPathSite(base.Site):
         """Initialize scraper.
 
         Args:
-            base_url (str): Base URL of the DigitalTowPath site (e.g. https://finetownny.gov)
+            base_url (str): Base URL of the DigitalTowPath site
+                (e.g. https://finetownny.gov)
             cache (Cache): Cache instance (default: new Cache())
         """
 
@@ -90,23 +91,26 @@ class DigitalTowPathSite(base.Site):
             logger.error(f"Invalid date format: {start_date} or {end_date}")
             return AssetCollection()
 
-        # Use caller-supplied timeout if given; preserve previously hardcoded values otherwise.
+        # Use caller-supplied timeout if given; preserve previously hardcoded
+        # values otherwise.
         scrape_timeout = timeout if timeout is not None else 30
         head_timeout = timeout if timeout is not None else 10
 
         ac = AssetCollection()
         processed_details = set()  # Track meeting detail IDs to avoid duplicates
 
-        # NOTE: Caching implementation needs to be rethought. It is only specific to the CLI,
-        # so each scraper should not be implementing things like determining cache paths
+        # NOTE: Caching implementation needs to be rethought. It is only
+        # specific to the CLI, so each scraper should not be implementing
+        # things like determining cache paths
         if "cache" in kwargs:
             logger.warning("Caching not implemented.")
-        # NOTE: Each scraper should not re-implement downloading assets, as this is a core
-        # function of the runner. The scraper should just return the URLs and metadata, and
-        # the runner should handle downloading.
+        # NOTE: Each scraper should not re-implement downloading assets, as
+        # this is a core function of the runner. The scraper should just
+        # return the URLs and metadata, and the runner should handle downloading.
         if "download" in kwargs:
             logger.warning(
-                "scrape(download=...) not implemented. Runner should handle downloading."
+                "scrape(download=...) not implemented."
+                " Runner should handle downloading."
             )
 
         # Step 1: Get all categories (committees)
@@ -119,7 +123,8 @@ class DigitalTowPathSite(base.Site):
             logger.error(f"Failed to fetch categories: {e}")
             return ac
 
-        # Step 2: For each category, fetch all meetings across all years in the date range
+        # Step 2: For each category, fetch all meetings across all years
+        # in the date range
         for category in categories:
             category_name = category["name"]
             logger.info(f"Processing category: {category_name}")
@@ -169,7 +174,8 @@ class DigitalTowPathSite(base.Site):
                                 head_timeout=head_timeout,
                             )
                             logger.debug(
-                                f"Added {asset_count} assets from meeting {meeting['detail_id']}"
+                                f"Added {asset_count} assets from meeting "
+                                f"{meeting['detail_id']}"
                             )
                         except Exception as e:
                             logger.warning(
@@ -248,7 +254,10 @@ class DigitalTowPathSite(base.Site):
             meeting_id = f"{self._site_meta['place']}-{meeting_date}-{detail_id}"
 
             # Create asset name
-            asset_name = f"{meeting_details.get('meeting_title', 'Meeting')} - {doc_type.capitalize()}"
+            asset_name = (
+                f"{meeting_details.get('meeting_title', 'Meeting')}"
+                f" - {doc_type.capitalize()}"
+            )
 
             # TODO: HEAD-per-document is slow and arguably a Runner/download-time
             # concern. Consider moving to base Asset or Runner layer.

--- a/civic_scraper/platforms/digital_tow_path/utils.py
+++ b/civic_scraper/platforms/digital_tow_path/utils.py
@@ -87,8 +87,14 @@ def get_categories(base_url, session=None, timeout=30):
 
     Example:
         [
-            {'name': 'Town Board', 'url': 'https://finetownny.gov/meetings/meetings/Town%20Board/2026'},
-            {'name': 'CF Arena', 'url': 'https://finetownny.gov/meetings/meetings/CF%20Arena/2026'},
+            {
+                'name': 'Town Board',
+                'url': 'https://finetownny.gov/meetings/meetings/Town%20Board/2026'
+            },
+            {
+                'name': 'CF Arena',
+                'url': 'https://finetownny.gov/meetings/meetings/CF%20Arena/2026'
+            },
             ...
         ]
     """
@@ -159,8 +165,14 @@ def get_other_years_from_soup(soup):
 
     Example:
         [
-            {'year': '2025', 'url': 'https://finetownny.gov/meetings/meetings/Town%20Board/2025'},
-            {'year': '2024', 'url': 'https://finetownny.gov/meetings/meetings/Town%20Board/2024'},
+            {
+                'year': '2025',
+                'url': 'https://finetownny.gov/meetings/meetings/Town%20Board/2025'
+            },
+            {
+                'year': '2024',
+                'url': 'https://finetownny.gov/meetings/meetings/Town%20Board/2024'
+            },
             ...
         ]
     """

--- a/civic_scraper/platforms/granicus/site.py
+++ b/civic_scraper/platforms/granicus/site.py
@@ -57,7 +57,11 @@ class GranicusSite(base.Site):
         session = Session()
         session.headers.update(
             {
-                "User-Agent": "Mozilla/5.0 (X11; CrOS x86_64 12871.102.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36"
+                "User-Agent": (
+                    "Mozilla/5.0 (X11; CrOS x86_64 12871.102.0)"
+                    " AppleWebKit/537.36 (KHTML, like Gecko)"
+                    " Chrome/81.0.4044.141 Safari/537.36"
+                )
             }
         )
 

--- a/civic_scraper/platforms/legistar/site.py
+++ b/civic_scraper/platforms/legistar/site.py
@@ -74,7 +74,8 @@ class Site(base.Site):
         for event in events:
             meeting_meta = self._extract_meeting_meta(event, webscraper)
             for asset_type in asset_list:
-                # Skip if a dictionary containing 'url' key is not present for the given asset type
+                # Skip if a dictionary containing 'url' key is not present
+                # for the given asset type
                 try:
                     asset = self._create_asset(event, meeting_meta, asset_type)
                 except TypeError:

--- a/civic_scraper/platforms/primegov/site.py
+++ b/civic_scraper/platforms/primegov/site.py
@@ -11,10 +11,12 @@ from civic_scraper.base.cache import Cache
 
 
 class PrimeGovSite(base.Site):
-    """For each Primegov site, there seems to be multiple API endpoints that can be queried:
+    """For each Primegov site, there seems to be multiple API endpoints
+    that can be queried:
     1. (GET) https://[city].primegov.com/api/meeting/search?from=[m/d/y]&to=[m/d/y]
     2. (GET) https://[city].primegov.com/v2/PublicPortal/ListUpcomingMeetings
-    2. (GET) https://[city].primegov.com/v2/PublicPortal/ListArchivedMeetings?year=[year]
+    2. (GET) https://[city].primegov.com/v2/PublicPortal/ListArchivedMeetings
+             ?year=[year]
     3. (POST) https://[city].primegov.com/api/search?
     """
 
@@ -29,7 +31,8 @@ class PrimeGovSite(base.Site):
 
         self.session = Session()
         self.session.headers["User-Agent"] = (
-            "Mozilla/5.0 (X11; CrOS x86_64 12871.102.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36"
+            "Mozilla/5.0 (X11; CrOS x86_64 12871.102.0) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/81.0.4044.141 Safari/537.36"
         )
 
         # Raise an error if a request gets a failing status code

--- a/civic_scraper/runner.py
+++ b/civic_scraper/runner.py
@@ -52,7 +52,8 @@ class Runner:
             site_urls (list): List of site URLs
             cache (bool): Optionally cache intermediate file artificats such as HTML
                 (default: False)
-            download (bool): Optionally download file assets such as agendas (default: False)
+            download (bool): Optionally download file assets such as agendas
+                (default: False)
 
         Outputs:
             Metadata CSV listing file assets for given sites and params.
@@ -85,7 +86,8 @@ class Runner:
         if download:
             download_counter = 0
             logger.info(
-                f"Downloading {len(asset_collection)} file asset(s) to {cache_obj.assets_path}..."
+                f"Downloading {len(asset_collection)} file asset(s) "
+                f"to {cache_obj.assets_path}..."
             )
             for asset in asset_collection:
                 # TODO: Add error-handling here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,14 +64,9 @@ docs = [
 ]
 
 [tool.flake8]
-max-line-length = 999
+max-line-length = 88
+extend-ignore = ["E203", "W503"]
 exclude = [".venv", ".tox", ".eggs", "build", "dist"]
-per-file-ignores = [
-    "civic_scraper/base/__init__.py:F401",
-    "civic_scraper/platforms/__init__.py:F401",
-    "tests/test_civic_plus_site.py:E501",
-    "tests/legistar_site.py:E402",
-]
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"

--- a/scripts/generate_civicplus_sites.py
+++ b/scripts/generate_civicplus_sites.py
@@ -6,12 +6,13 @@ VERSION: 2020-08-29
 DESCRIPTION:
 
 Given a csv of CivicPlus Agenda Center endpoints, check to see if each endpoint
-contains assets that it would be possible to scrape. Add each endpoint with valid assets and
-associated metadata to a csv.
+contains assets that it would be possible to scrape. Add each endpoint with valid assets
+and associated metadata to a csv.
 
 NOTE: Avoid overwriting previous versions of the csv produced by this file, since it is
-necessary to hand-key values in order to make them human-readable and to correctly categorize
-each endpoint. By default, this script appends new rows if a csv with the same path exists.
+necessary to hand-key values in order to make them human-readable and to correctly
+categorize each endpoint. By default, this script appends new rows if a csv with the
+same path exists.
 
 USAGE: From the command line,
 

--- a/scripts/scaffold_platform.py
+++ b/scripts/scaffold_platform.py
@@ -122,7 +122,9 @@ def test_scrape_with_date_range(civic_scraper_dir, set_default_env):
 
     # TODO: Replace EXPECTED_COUNT with the expected count for this date range.
     EXPECTED_COUNT = None  # ← Set this to an integer
-    assert EXPECTED_COUNT is not None, "Set EXPECTED_COUNT to the number of documents in the date range"
+    assert EXPECTED_COUNT is not None, (
+        "Set EXPECTED_COUNT to the number of documents in the date range"
+    )
     assert len(assets) == EXPECTED_COUNT
 
 
@@ -146,7 +148,8 @@ def scaffold_platform(platform_name, repo_root=None):
     """Generate scaffolding for a new platform scraper.
 
     Args:
-        platform_name (str): Platform name, lowercase with underscores (e.g., 'your_jurisdiction')
+        platform_name (str): Platform name, lowercase with underscores
+            (e.g., 'your_jurisdiction')
         repo_root (str): Root of the repository (default: current directory)
 
     Returns:
@@ -241,7 +244,8 @@ if __name__ == "__main__":
         print("     (They will fail with NotImplementedError — that's expected!)")
         print("  2. Implement Site.scrape() to make tests pass")
         print(
-            "  3. Run tests again — VCR auto-records HTTP cassettes on first passing run"
+            "  3. Run tests again"
+            " — VCR auto-records HTTP cassettes on first passing run"
         )
         print("  4. Subsequent runs replay from cassettes (fast, no network needed)")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,8 @@ import pytest
 #  https://vcrpy.readthedocs.io/en/latest/debugging.html
 # import vcr
 # import logging
-# logging.basicConfig() # you need to initialize logging, otherwise you will not see anything from vcrpy
+# logging.basicConfig()  # you need to initialize logging, otherwise
+#                         # you will not see anything from vcrpy
 # vcr_log = logging.getLogger("vcr")
 # vcr_log.setLevel(logging.INFO)
 
@@ -112,7 +113,10 @@ def asset_inputs():
             "place_name": "Nash County",
             "scraped_by": "civic-scraper_1.0.0-preview",
             "state_or_province": "nc",
-            "url": "http://nc-nashcounty.civicplus.com/AgendaCenter/ViewFile/Minutes/_05042020-381",
+            "url": (
+                "http://nc-nashcounty.civicplus.com/AgendaCenter"
+                "/ViewFile/Minutes/_05042020-381"
+            ),
         },
         {
             "asset_name": "May 4, 2020 Regular Meeting Agenda",
@@ -127,6 +131,9 @@ def asset_inputs():
             "place_name": "Nash County",
             "scraped_by": "civic-scraper_1.0.0-preview",
             "state_or_province": "nc",
-            "url": "http://nc-nashcounty.civicplus.com/AgendaCenter/ViewFile/Agenda/_05042020-381",
+            "url": (
+                "http://nc-nashcounty.civicplus.com/AgendaCenter"
+                "/ViewFile/Agenda/_05042020-381"
+            ),
         },
     ]

--- a/tests/legistar_site.py
+++ b/tests/legistar_site.py
@@ -1,16 +1,10 @@
 import logging
-import sys
-from pathlib import Path
 
 import urllib3
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
-PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
-sys.path.append(PROJECT_ROOT)
-
 from civic_scraper.platforms import LegistarSite
 
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 logging.basicConfig(level="DEBUG")
 
 legistar_sites = [

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -61,12 +61,14 @@ def test_asset_download(tmpdir, asset_inputs):
             asset.download(target_dir=tmpdir)
         assert mock_method.mock_calls == [
             call(
-                "http://nc-nashcounty.civicplus.com/AgendaCenter/ViewFile/Minutes/_05042020-381",
+                "http://nc-nashcounty.civicplus.com/AgendaCenter"
+                "/ViewFile/Minutes/_05042020-381",
                 allow_redirects=True,
                 timeout=None,
             ),
             call(
-                "http://nc-nashcounty.civicplus.com/AgendaCenter/ViewFile/Agenda/_05042020-381",
+                "http://nc-nashcounty.civicplus.com/AgendaCenter"
+                "/ViewFile/Agenda/_05042020-381",
                 allow_redirects=True,
                 timeout=None,
             ),

--- a/tests/test_civic_plus_parser.py
+++ b/tests/test_civic_plus_parser.py
@@ -43,7 +43,8 @@ def test_extract_all_asset_types_for_meeting(search_results_html):
 
 
 def test_parse_alameda():
-    "Parser should extract all items on page for Alameda WD, which uses a different page structure"
+    """Parser should extract all items on page for Alameda WD,
+    which uses a different page structure."""
     html = read_fixture("civplus_alameda_water.html")
     parser = Parser(html)
     data = parser.parse()

--- a/tests/test_civic_plus_site.py
+++ b/tests/test_civic_plus_site.py
@@ -24,9 +24,8 @@ def test_scrape_defaults():
     agenda = [asset for asset in assets if asset.url.endswith("Agenda/_05052020-382")][
         0
     ]
-    assert (
-        agenda.url
-        == "http://nc-nashcounty.civicplus.com/AgendaCenter/ViewFile/Agenda/_05052020-382"
+    assert agenda.url == (
+        "http://nc-nashcounty.civicplus.com/AgendaCenter/ViewFile/Agenda/_05052020-382"
     )
     assert agenda.committee_name == "Board of Commissioners"
     assert (

--- a/tests/test_legistar_site.py
+++ b/tests/test_legistar_site.py
@@ -52,9 +52,9 @@ def test_scrape_defaults():
         for asset in assets
         if asset.url.endswith("M=A&ID=957429&GUID=46C2C864-A1FF-4749-8B19-4915F2A65AF9")
     ][0]
-    assert (
-        agenda.url
-        == "https://nashville.legistar.com/View.ashx?M=A&ID=957429&GUID=46C2C864-A1FF-4749-8B19-4915F2A65AF9"
+    assert agenda.url == (
+        "https://nashville.legistar.com/View.ashx"
+        "?M=A&ID=957429&GUID=46C2C864-A1FF-4749-8B19-4915F2A65AF9"
     )
     assert agenda.committee_name == "Budget and Finance Committee"
     assert agenda.asset_type == "agenda"


### PR DESCRIPTION
## Overview

Tightens the flake8 linting configuration to enforce real code quality checks. Previously, max-line-length = 999 effectively disabled line-length enforcement, and broad per-file-ignores suppressed unused import and import-order warnings project-wide. Fixed linter errors after linter configuration changed.

Closes #230 

### Notes
- max-line-length set to 88 to match Black's default
- extend-ignore = ["E203", "W503"] added for Black compatibility — Black's output intentionally triggers these two rules
- F401 (unused imports) in __init__.py files resolved by adding __all__ declarations instead of suppressing the warning
- E402 (import not at top) in tests/legistar_site.py resolved by removing the sys.path.append hack — the package is installed via the dev environment so path manipulation is unnecessary
- All 40 E501 (line too long) violations fixed by wrapping docstrings, splitting string literals, and restructuring f-strings

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

I decided not to add new rules to the flake8 settings to avoid major code refactoring within a single PR. I suggest doing this in separate issues.

## Testing Instructions

- Check out this branch
- Create a virtualenv and install dev dependencies: pip install flake8 flake8-pyproject
- Run the linter: flake8 ./
- Expected output: no violations
