### PR TITLE
454 fix civic plus requests getting 404'd

### DIFF
--- a/civic_scraper/platforms/civic_plus/site.py
+++ b/civic_scraper/platforms/civic_plus/site.py
@@ -16,6 +16,14 @@ from .parser import Parser
 logger = logging.getLogger(__name__)
 
 
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    )
+}
+
+
 class Site(base.Site):
     def __init__(self, base_url, cache=None, parser_kls=Parser, place_name=None):
         super().__init__(base_url, cache=cache, parser_kls=parser_kls)
@@ -25,6 +33,8 @@ class Site(base.Site):
         self.state_or_province = self._get_asset_metadata(
             r"(?<=//)\w{2}(?=-)", base_url
         )
+        self.session = requests.Session()
+        self.session.headers.update(HEADERS)
 
     @property
     def place(self):
@@ -112,7 +122,7 @@ class Site(base.Site):
         # Search URLs follow the below pattern
         # /Search/?term=&CIDs=all&startDate=12/17/2020&endDate=12/18/2020&dateRange=&dateSelector=
         search_url = self.url.rstrip("/") + "/Search/"
-        response = requests.get(search_url, params=params, timeout=self.timeout)
+        response = self.session.get(search_url, params=params, timeout=self.timeout)
         return response.url, response.text
 
     def _convert_date(self, date_str):
@@ -148,13 +158,13 @@ class Site(base.Site):
             }
             # TODO: Add conditional here to short-circuit
             # header request based on method option
-            headers = requests.head(
+            response_headers = self.session.head(
                 url, allow_redirects=True, timeout=self.timeout
             ).headers
             asset_args.update(
                 {
-                    "content_type": headers["content-type"],
-                    "content_length": headers.get("content-length", -1),
+                    "content_type": response_headers["content-type"],
+                    "content_length": response_headers.get("content-length", -1),
                 }
             )
             assets.append(Asset(**asset_args))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,9 @@ per-file-ignores = [
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
+# fallback_version is used when setuptools-scm cannot determine a valid version
+# (e.g., during PR merge runs where the git ref is refs/pull/<number>/merge)
+fallback_version = "0.0.0"
 
 [tool.setuptools.packages.find]
 include = ["civic_scraper*"]


### PR DESCRIPTION
Closes: https://github.com/biglocalnews/bln-planning-eng/issues/454

A large percentage of CivicPlus sites are resulting in 0 assets when there are assets during the relevant time period.

Through testing a sample list of affected sites, I found that in the vast majority of cases, sites went from not working (0 assets) to working (> 0 assets) by adding a user agent header that is intended to look more like a web browser.

Further discussion in issue and post-mortem doc.