### PR TITLE
remove hardcoding of DTP site URLs

### DIFF
--- a/civic_scraper/cli.py
+++ b/civic_scraper/cli.py
@@ -107,7 +107,8 @@ def scrape(start_date, end_date, download, cache, timeout, platform, url, urls_f
         rows = list(reader)
         if "platform" in (reader.fieldnames or []):
             kwargs["site_urls"] = [
-                {"url": row["url"], "platform": row["platform"] or None} for row in rows
+                {"url": row["url"].strip(), "platform": row["platform"] or None}
+                for row in rows
             ]
         else:
             kwargs["site_urls"] = [row["url"] for row in rows]

--- a/civic_scraper/cli.py
+++ b/civic_scraper/cli.py
@@ -5,7 +5,7 @@ import os
 import click
 from click_option_group import RequiredMutuallyExclusiveOptionGroup, optgroup
 
-from civic_scraper.runner import Runner
+from civic_scraper.runner import PLATFORMS, Runner
 from civic_scraper.utils import default_user_home, today_local_str
 
 TODAY = today_local_str()
@@ -68,18 +68,23 @@ def cli():
     type=int,
     help="Timeout in seconds for HTTP requests. By default, no timeout.",
 )
+@click.option(
+    "--platform",
+    type=click.Choice(list(PLATFORMS.keys()), case_sensitive=False),
+    help="Force a specific platform instead of auto-detecting from the URL.",
+)
 @optgroup.group(
     "Site sources",
     cls=RequiredMutuallyExclusiveOptionGroup,
     help="Site URLs must be supplied on the command line or via CSV file.",
 )
-@optgroup.option("--url", help="Base URL for a single site to scraper.")
+@optgroup.option("--url", help="Base URL for a single site to scrape.")
 @optgroup.option(
     "--urls-file",
     type=click.File("r"),
-    help="CSV containing a 'url' field for target sites.",
+    help="CSV containing a 'url' field for target sites. An optional 'platform' column overrides auto-detection per row.",
 )
-def scrape(start_date, end_date, download, cache, timeout, url, urls_file):
+def scrape(start_date, end_date, download, cache, timeout, platform, url, urls_file):
     """Scrape one or more government sites."""
     cache_path = os.environ.get("CIVIC_SCRAPER_DIR", DEFAULT_USER_HOME)
     runner = Runner(cache_path=cache_path)
@@ -93,9 +98,17 @@ def scrape(start_date, end_date, download, cache, timeout, url, urls_file):
         "download": download,
         "timeout": timeout,
     }
+    if platform:
+        kwargs["platform"] = platform
     if url:
         kwargs["site_urls"] = [url]
     else:
         reader = csv.DictReader(urls_file.readlines())
-        kwargs["site_urls"] = [row["url"] for row in reader]
+        rows = list(reader)
+        if "platform" in (reader.fieldnames or []):
+            kwargs["site_urls"] = [
+                {"url": row["url"], "platform": row["platform"] or None} for row in rows
+            ]
+        else:
+            kwargs["site_urls"] = [row["url"] for row in rows]
     runner.scrape(**kwargs)

--- a/civic_scraper/platforms/digital_tow_path/site.py
+++ b/civic_scraper/platforms/digital_tow_path/site.py
@@ -1,14 +1,12 @@
 """
-Scraper for DigitalTowPath sites (e.g. finetownny.gov)
+Scraper for DigitalTowPath sites (e.g. finetownny.gov).
 
 For more information on the platform, see:
 - https://digitaltowpathny.gov/ (main site)
-
-To add a new DigitalTowPath site, add its domain and jurisdiction
-metadata to the SITES dict below.
 """
 
 import logging
+import re
 from datetime import datetime
 from urllib.parse import urlparse
 
@@ -19,21 +17,6 @@ from civic_scraper.base.asset import Asset, AssetCollection
 from . import utils
 
 logger = logging.getLogger(__name__)
-
-# Jurisdiction metadata keyed by domain. To add a new DigitalTowPath site,
-# add its domain here and the scraper will pick it up automatically.
-SITES = {
-    "finetownny.gov": {
-        "place": "fineny",
-        "place_name": "Fine New York",
-        "state": "ny",
-    },
-    "www.woodstockny.gov": {
-        "place": "woodstockny",
-        "place_name": "Woodstock New York",
-        "state": "ny",
-    },
-}
 
 
 class DigitalTowPathSite(base.Site):
@@ -47,22 +30,11 @@ class DigitalTowPathSite(base.Site):
             cache (Cache): Cache instance (default: new Cache())
         """
 
-        domain = urlparse(base_url).netloc
-        if domain not in SITES:
-            raise ValueError(
-                f"Unsupported site: {base_url}. "
-                f"Supported domains: {', '.join(SITES)}"
-            )
-
         super().__init__(base_url, cache=cache)
         self.base_url = base_url
         self.session = utils.create_session()
-        self._site_meta = SITES[domain]
-
-    @staticmethod
-    def can_scrape(url: str) -> bool:
-        """Determine if site can be scraped by this scraper."""
-        return urlparse(url).netloc in SITES
+        self.domain = urlparse(base_url).netloc.lower()
+        self.meeting_slug = re.sub(r"[^a-z0-9]+", "-", self.domain).strip("-")
 
     def scrape(
         self, start_date: str, end_date: str, timeout: int = None, **kwargs
@@ -245,7 +217,9 @@ class DigitalTowPathSite(base.Site):
             doc_url = doc["url"]
 
             # Create meeting ID
-            meeting_id = f"{self._site_meta['place']}-{meeting_date}-{detail_id}"
+            meeting_id = (
+                f"digitaltowpath_{self.meeting_slug}_{meeting_date}-{detail_id}"
+            )
 
             # Create asset name
             asset_name = f"{meeting_details.get('meeting_title', 'Meeting')} - {doc_type.capitalize()}"
@@ -274,9 +248,6 @@ class DigitalTowPathSite(base.Site):
                 asset_type=doc_type,
                 asset_name=asset_name,
                 committee_name=meeting_details.get("committee_name") or category_name,
-                place=self._site_meta["place"],
-                place_name=self._site_meta["place_name"],
-                state_or_province=self._site_meta["state"],
                 meeting_date=meeting_datetime,
                 meeting_id=meeting_id,
                 scraped_by=f"civic-scraper_{civic_scraper.__version__}",

--- a/civic_scraper/runner.py
+++ b/civic_scraper/runner.py
@@ -83,7 +83,11 @@ class Runner:
         )
         for entry in site_urls:
             if isinstance(entry, dict):
-                url = entry["url"]
+                url = entry.get("url")
+                if not url:
+                    raise ScraperError(
+                        "site_urls entries must be URL strings or dicts with a non-empty 'url' key"
+                    )
                 effective_platform = platform or entry.get("platform") or None
             else:
                 url = entry
@@ -123,10 +127,13 @@ class Runner:
 
     def _get_site_class_name(self, url, platform=None):
         if platform:
+            platform_key = str(platform).strip().lower()
             try:
-                return PLATFORMS[platform]
+                return PLATFORMS[platform_key]
             except KeyError:
-                raise ScraperError(f"Unknown platform: {platform}")
+                raise ScraperError(
+                    f"Unknown platform: {platform}. Must be one of: {', '.join(PLATFORMS)}"
+                )
         if re.search(r"(civicplus|AgendaCenter)", url):
             return "CivicPlusSite"
         raise ScraperError(f"No scraper found for {url}")

--- a/civic_scraper/runner.py
+++ b/civic_scraper/runner.py
@@ -4,9 +4,17 @@ import re
 
 from civic_scraper.base.asset import AssetCollection
 from civic_scraper.base.cache import Cache
-from civic_scraper.platforms import DigitalTowPathSite
 
 logger = logging.getLogger(__name__)
+
+PLATFORMS = {
+    "civic-clerk": "CivicClerkSite",
+    "civic-plus": "CivicPlusSite",
+    "digital-tow-path": "DigitalTowPathSite",
+    "granicus": "GranicusSite",
+    "legistar": "LegistarSite",
+    "primegov": "PrimeGovSite",
+}
 
 
 class ScraperError(Exception):
@@ -34,6 +42,7 @@ class Runner:
         cache=False,
         download=False,
         timeout=None,
+        platform=None,
     ):
         """Scrape file metadata and assets for a list of agency sites.
 
@@ -49,10 +58,16 @@ class Runner:
 
             start_date (str): Start date of scrape (YYYY-MM-DD)
             end_date (str): End date of scrape (YYYY-MM-DD)
-            site_urls (list): List of site URLs
+            site_urls (list): List of site URLs as strings, or dicts with a
+                ``url`` key and an optional ``platform`` key to override
+                auto-detection per entry.
             cache (bool): Optionally cache intermediate file artificats such as HTML
                 (default: False)
             download (bool): Optionally download file assets such as agendas (default: False)
+            timeout (int): Timeout in seconds for HTTP requests (default: None)
+            platform (str): Force a specific platform for all URLs instead of
+                auto-detecting from the URL. Overrides any per-entry ``platform``
+                value in ``site_urls``. Must be a key in ``PLATFORMS``.
 
         Outputs:
             Metadata CSV listing file assets for given sites and params.
@@ -66,8 +81,14 @@ class Runner:
         logger.info(
             f"Scraping {len(site_urls)} site(s) from {start_date} to {end_date}..."
         )
-        for url in site_urls:
-            SiteClass = self._get_site_class(url)
+        for entry in site_urls:
+            if isinstance(entry, dict):
+                url = entry["url"]
+                effective_platform = platform or entry.get("platform") or None
+            else:
+                url = entry
+                effective_platform = platform
+            SiteClass = self._get_site_class(url, platform=effective_platform)
             kwargs = {}
             if cache:
                 kwargs["cache"] = cache_obj
@@ -94,17 +115,18 @@ class Runner:
                 download_counter += 1
         return asset_collection
 
-    def _get_site_class(self, url):
-        class_name = self._get_site_class_name(url)
+    def _get_site_class(self, url, platform=None):
+        class_name = self._get_site_class_name(url, platform=platform)
         target_module = "civic_scraper.platforms"
         mod = importlib.import_module(target_module)
         return getattr(mod, class_name)
 
-    def _get_site_class_name(self, url):
+    def _get_site_class_name(self, url, platform=None):
+        if platform:
+            try:
+                return PLATFORMS[platform]
+            except KeyError:
+                raise ScraperError(f"Unknown platform: {platform}")
         if re.search(r"(civicplus|AgendaCenter)", url):
             return "CivicPlusSite"
-        # TODO: Discuss whether we want to elevate this pattern for all scrapers
-        # then we can just iterate through all scrapers and call can_scrape on each
-        if DigitalTowPathSite.can_scrape(url):
-            return "DigitalTowPathSite"
         raise ScraperError(f"No scraper found for {url}")

--- a/tests/fixtures/url_input_with_platform.csv
+++ b/tests/fixtures/url_input_with_platform.csv
@@ -1,0 +1,3 @@
+url,platform
+https://finetownny.gov/categories/,digital-tow-path
+http://nc-nashcounty.civicplus.com/AgendaCenter,civic-plus

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,3 +132,55 @@ def test_cli_timeout_option(runner_class, civic_scraper_dir):
     runner_instance = runner_class.return_value
     _, _, kwargs = runner_instance.scrape.mock_calls[0]
     assert kwargs["timeout"] == 30
+
+
+@patch("civic_scraper.cli.Runner")
+@pytest.mark.usefixtures("set_default_env")
+def test_cli_scraper_option(runner_class, civic_scraper_dir):
+    "CLI --platform should be passed through to Runner.scrape"
+    cli_runner = CliRunner()
+    cli_runner.invoke(
+        cli.cli,
+        [
+            "scrape",
+            "--start-date",
+            "2020-05-05",
+            "--end-date",
+            "2020-05-05",
+            "--platform",
+            "digital-tow-path",
+            "--url",
+            "https://townhope.digitaltowpath.org:10310/content",
+        ],
+    )
+    runner_instance = runner_class.return_value
+    _, _, kwargs = runner_instance.scrape.mock_calls[0]
+    assert kwargs["platform"] == "digital-tow-path"
+
+
+@patch("civic_scraper.cli.Runner")
+@pytest.mark.usefixtures("set_default_env")
+def test_cli_csv_platform_column(runner_class, civic_scraper_dir):
+    "CSV 'platform' column should be passed as per-URL platform dicts to Runner.scrape"
+    cli_runner = CliRunner()
+    cli_runner.invoke(
+        cli.cli,
+        [
+            "scrape",
+            "--start-date",
+            "2020-05-05",
+            "--end-date",
+            "2020-05-05",
+            "--urls-file",
+            path_to_test_dir_file("fixtures/url_input_with_platform.csv"),
+        ],
+    )
+    runner_instance = runner_class.return_value
+    _, _, kwargs = runner_instance.scrape.mock_calls[0]
+    assert kwargs["site_urls"] == [
+        {"url": "https://finetownny.gov/categories/", "platform": "digital-tow-path"},
+        {
+            "url": "http://nc-nashcounty.civicplus.com/AgendaCenter",
+            "platform": "civic-plus",
+        },
+    ]

--- a/tests/test_digital_tow_path_site.py
+++ b/tests/test_digital_tow_path_site.py
@@ -20,6 +20,13 @@ def test_scrape_with_date_range(civic_scraper_dir, set_default_env):
 
     # Based on VCR recording on Feb. 12, 2026, there should be exactly 2 assets
     assert len(assets) == 2, "Should find exactly 2 assets in the date range"
+    assert all(asset.place is None for asset in assets)
+    assert all(asset.place_name is None for asset in assets)
+    assert all(asset.state_or_province is None for asset in assets)
+    assert all(
+        asset.meeting_id.startswith("digitaltowpath_finetownny-gov_")
+        for asset in assets
+    )
 
 
 def test_site_initialization():
@@ -31,14 +38,6 @@ def test_site_initialization():
     assert site.url == "https://finetownny.gov/categories/"
 
 
-def test_can_scrape_supported():
-    assert DigitalTowPathSite.can_scrape("https://finetownny.gov/categories/") is True
-
-
-def test_can_scrape_unsupported():
-    assert DigitalTowPathSite.can_scrape("https://example.com/meetings") is False
-
-
-def test_unsupported_domain_raises():
-    with pytest.raises(ValueError, match="Unsupported site"):
-        DigitalTowPathSite("https://example.com/meetings")
+def test_site_initialization_does_not_require_known_domain():
+    site = DigitalTowPathSite("https://example.com/meetings")
+    assert site.base_url == "https://example.com/meetings"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from civic_scraper.runner import Runner
+from civic_scraper.runner import Runner, ScraperError
 
 
 @pytest.mark.usefixtures("set_default_env")
@@ -138,3 +138,70 @@ def test_runner_passes_timeout(asset_collection, civic_scraper_dir, one_site_url
         )
         assets_dir = str(Path(civic_scraper_dir).joinpath("assets"))
         mock_asset.download.assert_called_once_with(assets_dir, timeout=30)
+
+
+@pytest.mark.usefixtures("set_default_env")
+def test_runner_passes_forced_scraper(civic_scraper_dir, one_site_url):
+    site_class = MagicMock(name="DigitalTowPathSite")
+    to_patch = "civic_scraper.runner.Runner._get_site_class"
+    with patch(to_patch) as mock_method:
+        mock_method.return_value = site_class
+        start_date = end_date = "2020-12-01"
+        r = Runner(civic_scraper_dir)
+        r.scrape(
+            start_date,
+            end_date,
+            one_site_url,
+            platform="digital-tow-path",
+        )
+        mock_method.assert_called_once_with(
+            "http://nc-nashcounty.civicplus.com/AgendaCenter",
+            platform="digital-tow-path",
+        )
+
+
+def test_runner_get_site_class_name_forced_scraper():
+    r = Runner()
+    assert (
+        r._get_site_class_name(
+            "https://example.com",
+            platform="digital-tow-path",
+        )
+        == "DigitalTowPathSite"
+    )
+
+
+def test_runner_get_site_class_name_unknown_url_raises():
+    r = Runner()
+    with pytest.raises(ScraperError, match="No scraper found for https://example.com"):
+        r._get_site_class_name("https://example.com")
+
+
+def test_runner_get_site_class_name_unknown_scraper_raises():
+    r = Runner()
+    with pytest.raises(ScraperError, match="Unknown platform: bad-name"):
+        r._get_site_class_name("https://example.com", platform="bad-name")
+
+
+def test_runner_per_url_platform_from_dict(civic_scraper_dir):
+    "site_urls dicts with a 'platform' key should override auto-detection per URL"
+    site_class = MagicMock(name="DigitalTowPathSite")
+    site_class.return_value.scrape.return_value = []
+    to_patch = "civic_scraper.runner.Runner._get_site_class"
+    with patch(to_patch) as mock_get_class:
+        mock_get_class.return_value = site_class
+        r = Runner(civic_scraper_dir)
+        r.scrape(
+            "2020-12-01",
+            "2020-12-01",
+            site_urls=[
+                {
+                    "url": "https://finetownny.gov/categories/",
+                    "platform": "digital-tow-path",
+                }
+            ],
+        )
+        mock_get_class.assert_called_once_with(
+            "https://finetownny.gov/categories/",
+            platform="digital-tow-path",
+        )


### PR DESCRIPTION
## Summary

This PR removes the hardcoded `SITES` allowlist from the `DigitalTowPathSite` scraper and replaces `can_scrape`-based auto-detection with an explicit `--platform` CLI flag. It also adds support for a `platform` column in `--urls-file` CSVs, allowing each row to specify its platform independently.

Closes: https://github.com/biglocalnews/bln-planning-eng/issues/463

## Changes

### `civic_scraper/platforms/digital_tow_path/site.py`
- Removed the `SITES` dict (hardcoded domain → jurisdiction metadata)
- Removed `can_scrape()` static method
- `DigitalTowPathSite.__init__` no longer raises on unknown domains — any URL is accepted
- `place`, `place_name`, and `state_or_province` are no longer set on assets (now `None`); the scraper doesn't have a reliable way to know these without the allowlist
- `meeting_id` format changed from `{place}-{date}-{id}` to `digitaltowpath_{domain-slug}_{date}-{id}`, aligning with the `{platform}_{instance}_{id}` convention used by all other scrapers

### `civic_scraper/runner.py`
- Added `PLATFORMS` dict mapping platform name slugs to class names (single source of truth shared with CLI)
- `Runner.scrape()` accepts a new `platform` keyword argument
- `site_urls` entries may now be plain URL strings or dicts with `url` and optional `platform` keys for per-URL platform overrides
- `_get_site_class_name()` uses the explicit platform name when provided, bypassing auto-detection; the global `platform` argument takes precedence over per-entry values
- Removed the `DigitalTowPathSite.can_scrape()` call from auto-detection logic
- Updated `scrape()` docstring to document all parameters

### `civic_scraper/cli.py`
- Added `--platform` option with a `click.Choice` driven by `PLATFORMS` from `runner.py` (no duplicate list)
- `--urls-file` CSVs now support an optional `platform` column; when present, each row's value is used for auto-detection override; rows with an empty `platform` cell fall back to auto-detection
- `--platform` flag overrides all per-row `platform` values when both are present
- Passes `platform` through to `Runner.scrape()` when provided
- Fixed a typo in `--url` help text ("scraper" → "scrape")
- Updated `--urls-file` help text to document the `platform` column

### Tests
- Removed `test_can_scrape_supported`, `test_can_scrape_unsupported`, `test_unsupported_domain_raises`
- Added `test_site_initialization_does_not_require_known_domain`
- Added assertions on `place`/`place_name`/`state_or_province` being `None` and new `meeting_id` format
- Added `test_cli_scraper_option`, `test_cli_csv_platform_column`
- Added `test_runner_passes_forced_scraper`, `test_runner_get_site_class_name_forced_scraper`, `test_runner_get_site_class_name_unknown_scraper_raises`, `test_runner_per_url_platform_from_dict`
- Added `tests/fixtures/url_input_with_platform.csv`

## Motivation

The hardcoded list made it impossible to scrape any DigitalTowPath site not manually added to the source. The new approach lets users scrape any DTP site by passing `--platform digital-tow-path` on the CLI, without requiring a code change per site.

## Usage

**Single site:**
```bash
uv run civic-scraper scrape \
  --platform digital-tow-path \
  --url "https://townhope.digitaltowpath.org:10310/content" \
  --start-date 2026-01-01 \
  --end-date 2026-12-31
```

**Mixed-platform CSV:**
```csv
url,platform
https://townhope.digitaltowpath.org:10310/content,digital-tow-path
http://nc-nashcounty.civicplus.com/AgendaCenter,civic-plus
https://seattle.legistar.com/Calendar.aspx,legistar
```
```bash
uv run civic-scraper scrape \
  --urls-file sites.csv \
  --start-date 2026-01-01 \
  --end-date 2026-12-31
```

## Breaking changes

- `place`, `place_name`, and `state_or_province` fields on DTP assets are now always `None`
- `meeting_id` format has changed for existing DTP sites
- `DigitalTowPathSite.can_scrape()` no longer exists
- DTP sites are no longer auto-detected from the URL; `--platform digital-tow-path` must be passed explicitly
- `--scraper` CLI flag renamed to `--platform`; `Runner.scrape(scraper=)` renamed to `Runner.scrape(platform=)`; `SCRAPER_CLASSES` renamed to `PLATFORMS`
