### PR TITLE
502: Add option to get legistar content metadata

### DIFF
--- a/civic_scraper/platforms/legistar/site.py
+++ b/civic_scraper/platforms/legistar/site.py
@@ -38,6 +38,7 @@ class Site(base.Site):
         file_size=None,
         asset_list=None,
         timeout=None,
+        fetch_file_meta=False,
     ):
         """Scrape a government website for metadata and/or docs.
         Args:
@@ -81,7 +82,12 @@ class Site(base.Site):
                     continue
                 # Apply date and other filters
                 if self._skippable(
-                    asset, start_date, end_date, file_size=file_size, download=download
+                    asset,
+                    start_date,
+                    end_date,
+                    file_size=file_size,
+                    download=download,
+                    fetch_file_meta=fetch_file_meta,
                 ):
                     continue
                 ac.append(asset)
@@ -104,8 +110,8 @@ class Site(base.Site):
         headers = requests.head(
             asset.url, allow_redirects=True, timeout=self.timeout
         ).headers
-        asset.content_type = headers["content-type"]
-        asset.content_length = headers["content-length"]
+        asset.content_type = headers.get("content-type")
+        asset.content_length = headers.get("content-length", -1)
 
     def _create_asset(self, event, meeting_meta, asset_type):
         name_bits = [self._event_name(event)]
@@ -170,7 +176,9 @@ class Site(base.Site):
         except (KeyError, TypeError):
             return event["Name"]
 
-    def _skippable(self, asset, start_date, end_date, file_size=None, download=False):
+    def _skippable(
+        self, asset, start_date, end_date, file_size=None, download=False, fetch_file_meta=False
+    ):
         start = parse_date(start_date)
         end = parse_date(end_date)
         # Use a generic (non-timezone aware) date for filtering
@@ -184,8 +192,8 @@ class Site(base.Site):
         # Skip if meeting date isn't between/equal to start and end dates
         if not start <= meeting_date <= end:
             return True
-        # Add Content Type and Length when download specified
-        if download:
+        # Add Content Type and Length when download or fetch_file_meta specified
+        if download or fetch_file_meta:
             self._add_file_meta(asset)
         # if file_size and download are given, then check byte count
         if file_size and download:

--- a/civic_scraper/platforms/legistar/site.py
+++ b/civic_scraper/platforms/legistar/site.py
@@ -180,7 +180,13 @@ class Site(base.Site):
             return event["Name"]
 
     def _skippable(
-        self, asset, start_date, end_date, file_size=None, download=False, fetch_file_meta=False
+        self,
+        asset,
+        start_date,
+        end_date,
+        file_size=None,
+        download=False,
+        fetch_file_meta=False,
     ):
         start = parse_date(start_date)
         end = parse_date(end_date)

--- a/civic_scraper/platforms/legistar/site.py
+++ b/civic_scraper/platforms/legistar/site.py
@@ -116,7 +116,7 @@ class Site(base.Site):
             asset.url, allow_redirects=True, timeout=self.timeout
         ).headers
         asset.content_type = headers.get("content-type")
-        asset.content_length = headers.get("content-length", -1)
+        asset.content_length = headers.get("content-length", "-1")
 
     def _create_asset(self, event, meeting_meta, asset_type):
         name_bits = [self._event_name(event)]

--- a/civic_scraper/platforms/legistar/site.py
+++ b/civic_scraper/platforms/legistar/site.py
@@ -47,7 +47,12 @@ class Site(base.Site):
             download (bool): Download file assets such as PDFs (default: False)
             file_size (float): Max size in Megabytes of file assets to download
             asset_list (list): Optional list of SUPPORTED_ASSET_TYPES to
-                to limit items to be scraped (e.g. agenda, minutes). (default: [])
+                limit items to be scraped (e.g. agenda, minutes).
+                (default: ["Agenda", "Minutes"])
+            timeout (int): Timeout in seconds for HTTP requests (default: None)
+            fetch_file_meta (bool): Populate content_type and content_length via
+                HEAD request for each asset without downloading. Implied when
+                download=True. (default: False)
         Returns:
             AssetCollection: A sequence of Asset instances
         """
@@ -144,8 +149,6 @@ class Site(base.Site):
             meeting_datetime = " ".join((date_info, "12:00 AM"))
 
         meeting_time = scraper.toTime(meeting_datetime)
-
-        # use regex to match pattern #/#/#; raise warning if no match
 
         # get event ID
         if type(event[scraper.event_info_key]) is dict:

--- a/tests/test_legistar_site.py
+++ b/tests/test_legistar_site.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import pytz
@@ -66,7 +66,7 @@ def test_scrape_defaults():
         datetime.datetime(2022, 4, 18, 17, 0)
     )
     assert expected_dtz == agenda.meeting_time
-    # Content Type and Length are only captured if download flag is True
+    # Content Type and Length are only captured with download=True or fetch_file_meta=True
     assert agenda.content_type is None
     assert agenda.content_length is None
 
@@ -185,3 +185,28 @@ def test_multiyear_scrape(tmpdir):
     site = LegistarSite(url, **config)
     assets = site.scrape(start_date=start_date, end_date=end_date)
     assert len(assets) == 4
+
+
+@pytest.mark.vcr("test_scrape_download_true.yaml")
+@patch("civic_scraper.platforms.legistar.site.requests.head")
+def test_scrape_fetch_file_meta(mock_head):
+    "fetch_file_meta=True should populate content_type and content_length without downloading files"
+    mock_response = MagicMock()
+    mock_response.headers.get.side_effect = lambda key, default=None: {
+        "content-type": "application/pdf",
+        "content-length": "453581",
+    }.get(key, default)
+    mock_head.return_value = mock_response
+
+    url = "https://nashville.legistar.com/Calendar.aspx"
+    config = {"timezone": "US/Central"}
+    scrape_date = "2022-04-05"
+    site = LegistarSite(url, **config)
+    assets = site.scrape(
+        start_date=scrape_date, end_date=scrape_date, fetch_file_meta=True
+    )
+    assert len(assets) == 2
+    assert mock_head.call_count == 2
+    for asset in assets:
+        assert asset.content_type == "application/pdf"
+        assert asset.content_length == "453581"

--- a/tests/test_legistar_site.py
+++ b/tests/test_legistar_site.py
@@ -187,7 +187,7 @@ def test_multiyear_scrape(tmpdir):
     assert len(assets) == 4
 
 
-@pytest.mark.vcr("test_scrape_download_true.yaml")
+@pytest.mark.vcr()
 @patch("civic_scraper.platforms.legistar.site.requests.head")
 def test_scrape_fetch_file_meta(mock_head):
     "fetch_file_meta=True should populate content_type and content_length without downloading files"


### PR DESCRIPTION
## Overview

#### Problem this PR solves:

The Legistar scraper leaves content_length blank on all document assets. The Legistar API/calendar response doesn't include file size, so unlike CivicPlus (which reads it from page metadata during scraping), Legistar assets are created with content_length = None and it's only populated if download=True is passed to scrape(). This means routine scrape-only runs (the common case) produce Legistar assets with no size information.

#### Implementation

Because the content length flow requires an additional head request per doc, I added it as an optional flag (some clients don't care about this and wouldn't want double calls!).

`civic_scraper/platforms/legistar/site.py`
- Added fetch_file_meta=False param to scrape() and _skippable()
- _add_file_meta() now triggers when download or fetch_file_meta
- _add_file_meta() uses .get() for both headers so a missing Content-Length returns -1 instead of raising a KeyError

`tests/test_legistar_site.py`
- Added test_scrape_fetch_file_meta — reuses the existing VCR cassette for calendar data, mocks requests.head to verify content_type/content_length are populated and no files are downloaded
- Updated stale comment to mention fetch_file_meta=True

### Demo

To get content-length for legistar site a call would need the new param set to True - eg:

`assets = site.scrape(start_date="2026-01-01", end_date="2026-06-17", fetch_file_meta=True)`

```
https://duluth-mn.legistar.com/Calendar.aspx
  agenda          content_length='202544'     url=https://duluth-mn.legistar.com/View.ashx?M=A&ID=1398598&GUID=4C2C5A00-8367-44A5-
  agenda          content_length='200960'     url=https://duluth-mn.legistar.com/View.ashx?M=A&ID=1370410&GUID=B169674E-8AC7-4E49-
  agenda          content_length='272832'     url=https://duluth-mn.legistar.com/View.ashx?M=A&ID=1396386&GUID=67C1B154-5A1E-43C2-
  ... and 120 more

https://fpdcc.legistar.com/Calendar.aspx
  agenda          content_length='483749'     url=https://fpdcc.legistar.com/View.ashx?M=A&ID=1351419&GUID=4D3C2DE8-F5E2-4861-B5AF
  agenda          content_length='183526'     url=https://fpdcc.legistar.com/View.ashx?M=A&ID=1417445&GUID=7A12F2C3-74A2-492D-9E47
  minutes         content_length='224007'     url=https://fpdcc.legistar.com/View.ashx?M=M&ID=1417445&GUID=7A12F2C3-74A2-492D-9E47
  ... and 96 more
```

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* `tox` 
* Run example and notice that content length is coming back when fetch_file_meta=True (nix that to see the default)

```
python - <<'EOF'
from civic_scraper.platforms import LegistarSite

urls = [
    "https://duluth-mn.legistar.com/Calendar.aspx",
    "https://sonoma-county.legistar.com/Calendar.aspx",
]

for url in urls:
    site = LegistarSite(url, timezone="US/Central")
    assets = site.scrape(start_date="2026-01-01", end_date="2026-06-17", fetch_file_meta=True)
    print(f"\n{url}")
    for a in assets[:3]:
        print(f"  {a.asset_type:15} content_length={a.content_length!r:12} url={a.url[:80]}")
    if len(assets) > 3:
        print(f"  ... and {len(assets) - 3} more")
EOF

```

### After - with fetch_file_meta=True - has content length

```

https://duluth-mn.legistar.com/Calendar.aspx
  agenda          content_length='202544'     url=https://duluth-mn.legistar.com/View.ashx?M=A&ID=1398598&GUID=4C2C5A00-8367-44A5-
  agenda          content_length='200960'     url=https://duluth-mn.legistar.com/View.ashx?M=A&ID=1370410&GUID=B169674E-8AC7-4E49-
  agenda          content_length='272832'     url=https://duluth-mn.legistar.com/View.ashx?M=A&ID=1396386&GUID=67C1B154-5A1E-43C2-
  ... and 120 more
 
https://sonoma-county.legistar.com/Calendar.aspx
  agenda          content_length='2688376'    url=https://sonoma-county.legistar.com/View.ashx?M=A&ID=1351034&GUID=22496CC9-D1BC-4
  agenda          content_length='2688376'    url=https://sonoma-county.legistar.com/View.ashx?M=A&ID=1351032&GUID=6127CFED-0141-4
  agenda          content_length='2688376'    url=https://sonoma-county.legistar.com/View.ashx?M=A&ID=1351025&GUID=43B105D4-810E-4
  ... and 66 more
```

### Before / new default - no content length 

```
python - <<'EOF'
from civic_scraper.platforms import LegistarSite

urls = [
    "https://duluth-mn.legistar.com/Calendar.aspx",
    "https://sonoma-county.legistar.com/Calendar.aspx",
]

for url in urls:
    site = LegistarSite(url, timezone="US/Central")
    assets = site.scrape(start_date="2026-01-01", end_date="2026-06-17")                      
    print(f"\n{url}")
    for a in assets[:3]:
        print(f"  {a.asset_type:15} content_length={a.content_length!r:12} url={a.url[:80]}")
    if len(assets) > 3:
        print(f"  ... and {len(assets) - 3} more")
EOF

https://duluth-mn.legistar.com/Calendar.aspx
  agenda          content_length=None         url=https://duluth-mn.legistar.com/View.ashx?M=A&ID=1398598&GUID=4C2C5A00-8367-44A5-
  agenda          content_length=None         url=https://duluth-mn.legistar.com/View.ashx?M=A&ID=1370410&GUID=B169674E-8AC7-4E49-
  agenda          content_length=None         url=https://duluth-mn.legistar.com/View.ashx?M=A&ID=1396386&GUID=67C1B154-5A1E-43C2-
  ... and 120 more

https://sonoma-county.legistar.com/Calendar.aspx
  agenda          content_length=None         url=https://sonoma-county.legistar.com/View.ashx?M=A&ID=1351034&GUID=22496CC9-D1BC-4
  agenda          content_length=None         url=https://sonoma-county.legistar.com/View.ashx?M=A&ID=1351032&GUID=6127CFED-0141-4
  agenda          content_length=None         url=https://sonoma-county.legistar.com/View.ashx?M=A&ID=1351025&GUID=43B105D4-810E-4
  ... and 66 more
```